### PR TITLE
Only shift cycles

### DIFF
--- a/exchange_cycle_testing.py
+++ b/exchange_cycle_testing.py
@@ -59,7 +59,7 @@ def find_random_hamiltonian_path(groups: List[List[str]]) -> List[str]:
 
         previous_group = current_group
 
-    return standardize_path_start(path)
+    return path
 
 
 def is_path_a_cycle(mypath: List[str]) -> bool:
@@ -114,8 +114,9 @@ def main():
 
             if is_path_a_cycle(path):
                 cycle_count += 1
-                cycles.append('-'.join(path))
-                # print(f'cycle: {path}')
+                shifted_path = standardize_path_start(path)
+                cycles.append('-'.join(shifted_path))
+                # print(f'cycle: {shifted_path}')
             else:
                 non_cycle_count += 1
                 # print(f'non-cycle: {path}')


### PR DESCRIPTION
Only cycles can be shifted. Shifting a path that is not a cycle, introduces
a new edge that does not actually exist. For example, [A1, B1, C1, A2] is a
valid path that is not a cycle. There is no edge between A1 and A2 since they
are in the same group.

Shifting this in any direction and moving A1 and A2 out of their current first
and last positions introduces an edge between A1 and A2. e.g. [B1, C1, A2, A1]
or [A2, A1, B1, C1].

If a path is a cycle, then that means there does exist an edge between the
first and last nodes of the path. Therefore, shifting a cycle does not
introduce any new edges.